### PR TITLE
get line sensor in sync across HW. SW

### DIFF
--- a/fwdedu/jacdac.ts
+++ b/fwdedu/jacdac.ts
@@ -32,9 +32,9 @@ namespace robot.drivers {
         }
 
         lineState(state: number[]) {
-            state[1] = fwdSensors.line1.brightness() ? 0 : 400
+            state[1] = fwdSensors.line3.brightness() ? 0 : 400
             state[2] = fwdSensors.line2.brightness() ? 0 : 400
-            state[3] = fwdSensors.line3.brightness() ? 0 : 400
+            state[3] = fwdSensors.line1.brightness() ? 0 : 400
 
         }
     }

--- a/radio.ts
+++ b/radio.ts
@@ -80,9 +80,9 @@ namespace robot {
                 msg |= robots.RobotLineState.Left | robots.RobotLineState.Right
             else {
                 if (current[RobotLineDetector.Left] >= threshold)
-                    msg |= robots.RobotLineState.Right              // Left/Right between RobotLineDetector and RobotLineState swapped
+                    msg |= robots.RobotLineState.Left           
                 if (current[RobotLineDetector.Right] >= threshold)
-                    msg |= robots.RobotLineState.Left
+                    msg |= robots.RobotLineState.Right
             }
             // line lost
             lost = false
@@ -91,11 +91,11 @@ namespace robot {
                 prev[RobotLineDetector.Middle] < threshold
             ) {
                 if (prev[RobotLineDetector.Left] >= threshold) {
-                    msg = robots.RobotCompactCommand.LineLostRight
+                    msg = robots.RobotCompactCommand.LineLostLeft
                     lost = true
                 }
                 else if (prev[RobotLineDetector.Right] >= threshold) {
-                    msg = robots.RobotCompactCommand.LineLostLeft
+                    msg = robots.RobotCompactCommand.LineLostRight
                     lost = true
                 }
             }

--- a/radio.ts
+++ b/radio.ts
@@ -91,11 +91,11 @@ namespace robot {
                 prev[RobotLineDetector.Middle] < threshold
             ) {
                 if (prev[RobotLineDetector.Left] >= threshold) {
-                    msg = robots.RobotCompactCommand.LineLostLeft
+                    msg = robots.RobotCompactCommand.LineLostRight
                     lost = true
                 }
                 else if (prev[RobotLineDetector.Right] >= threshold) {
-                    msg = robots.RobotCompactCommand.LineLostRight
+                    msg = robots.RobotCompactCommand.LineLostLeft
                     lost = true
                 }
             }

--- a/robotdriver.ts
+++ b/robotdriver.ts
@@ -290,8 +290,8 @@ namespace robot {
             const threshold = this.robot.lineHighThreshold
             const s = this.currentLineState
             for (let i = 0; i < 5; ++i) {
-                if (s[i] >= threshold) led.plot(i, 4)
-                else led.unplot(i, 4)
+                if (s[i] >= threshold) led.plot(4-i, 4)
+                else led.unplot(4-i, 4)
             }
         }
 

--- a/robots/elecfreakscutebot.ts
+++ b/robots/elecfreakscutebot.ts
@@ -8,8 +8,8 @@ namespace robot {
             this.leds = new drivers.WS2812bLEDStrip(DigitalPin.P15, 2)
             this.sonar = new drivers.SR04Sonar(DigitalPin.P12, DigitalPin.P8)
             this.lineDetectors = new drivers.DigitalPinLineDetectors(
-                DigitalPin.P14,
                 DigitalPin.P13,
+                DigitalPin.P14,
                 false
             )
             this.arms = [new drivers.ServoArm(45, 135, AnalogPin.P1), new drivers.ServoArm(45, 135, AnalogPin.P2)]

--- a/robots/kittenbotrobotbit.ts
+++ b/robots/kittenbotrobotbit.ts
@@ -97,7 +97,7 @@ namespace robot {
 
         if (index > 4 || index <= 0) return
         let pp = (index - 1) * 2
-        let pn = (index - 1) * 2 + 1
+        let pn = pp + 1
         if (speed >= 0) {
             setPwm(pp, 0, speed)
             setPwm(pn, 0, 0)
@@ -118,11 +118,7 @@ namespace robot {
         constructor(public readonly servo: Servos) {}
         start() {}
         open(aperture: number) {
-            if (aperture > 50) {
-                setServoAngle(this.servo, 0)
-            } else {
-                setServoAngle(this.servo, 90)
-            }
+            setServoAngle(this.servo, aperture > 50 ? 0 : 90)
         }
     }
 
@@ -137,7 +133,7 @@ namespace robot {
                 false
             )
             this.maxLineSpeed = 150
-            this.arms = [new PwmArm(Servos.S1)]
+            // this.arms = [new PwmArm(Servos.S1)]   // remove to fit in V1 space
         }
 
         start() {


### PR DESCRIPTION
OK. This was easy to fix. The confusion was that the LED display didn't show line sensors in proper order. Then P13 and P14 were (incorrectly) switched in CuteBot, which caused more confusion, I reordered the radio communication (also incorrectly). All sorted now. Also. I had line sensor order for fwd edu reversed.   Other fixes I made previously to radio comms have caused one of the hex files not to fit anymore.  I disabled arm in that one to make it fit.